### PR TITLE
fix: get all default ordering

### DIFF
--- a/src/controllers/model-getall.js
+++ b/src/controllers/model-getall.js
@@ -14,7 +14,7 @@ module.exports = _conf => {
     const fieldsToSearchIn = req.query.search_in_fields || [];
     const page = parseInt(req.query.page || 1);
     const rowsPerPage = parseInt(req.query.rows || 10);
-    const defaultOrdering = [ ['_id', 'DESC'] ];
+    const defaultOrdering = [ ['_id', 'desc'] ];
     const order = req.query.order || null;
 
     const currentModel = fnHelper.getModelObject(modelName);


### PR DESCRIPTION
The error thrown by the module `TypeError: Invalid sort value: { _id: DESC }`

Mongoose needs values among these : `asc, desc, ascending, descending, 1, and -1`

https://mongoosejs.com/docs/api/query.html#Query.prototype.sort()