### PR TITLE
fix: ObjectId case sensitive

### DIFF
--- a/src/helpers/functions.js
+++ b/src/helpers/functions.js
@@ -284,7 +284,7 @@ module.exports = _conf => {
     let fieldsToPopulate = [];
     fieldsToFetch.forEach(field => {
       const matchingField = keys.find(k => k.path === field);
-      if (matchingField && matchingField.type === 'ObjectID' && (matchingField.ref || matchingField.refPath)) {
+      if (matchingField && matchingField.type === 'ObjectId' && (matchingField.ref || matchingField.refPath)) {
 
         let fieldToSelect = '_id';
         let toPush = {


### PR DESCRIPTION
ObjectId doesn't match with ObjectID, so the referenced models aren't populate with data.
ObjectId is used in plenty of other usecases.